### PR TITLE
Adds simple scheme delimiter validation

### DIFF
--- a/lib/url_tincture.ex
+++ b/lib/url_tincture.ex
@@ -103,10 +103,13 @@ defmodule UrlTincture do
   def canonicalize_url(url, opts) do
     opts = Keyword.merge([force_http: true, campaign_params: :keep], opts)
 
-    parseable = case opts[:force_http] do
-      true -> force_http(url)
-      false -> url
-    end
+    parseable =
+      if opts[:force_http] && valid_scheme_delimiter?(url) do
+        force_http(url)
+      else
+        url
+      end
+
     result = parseable
     |> String.strip
     |> String.downcase
@@ -247,5 +250,14 @@ defmodule UrlTincture do
       true -> 3
     end
     host |> String.split(".") |> Enum.take(parts * -1) |> Enum.join(".")
+  end
+
+  @spec valid_scheme_delimiter?(String.t) :: boolean()
+  def valid_scheme_delimiter?(url) do
+    if String.contains?(url, "//") do
+      String.contains?(url, "://")
+    else
+      true
+    end
   end
 end

--- a/test/url_tincture_test.exs
+++ b/test/url_tincture_test.exs
@@ -159,6 +159,11 @@ defmodule UrlTinctureTest do
     assert(UrlTincture.can_parse_safely?("https://google.com") == {:ok, "https://google.com"})
   end
 
+  test "canonicalize_url/2 errors with invalid scheme delimiter"do
+    result = UrlTincture.canonicalize_url("htsdfatps//andres2-perlu.tumblr.com")
+    assert result == {:error, "invalid url"}
+  end
+
   def http_check(urls, func) do
     for {expected, ordinal, url} <- urls do
       result = Tuple.to_list(func.(url)) |> Enum.at(0)


### PR DESCRIPTION
Why:

* We'd like for urls like this one,
  "htsdfatps//andres2-perlu.tumblr.com", to error when passed in to
  UrlTincture.canonicalize_url/1

This change addresses the need by:

* Editing UrlTincture.canonicalize_url/1 for it to check that if there
  are two forward slashes that they are preceded by a colon. Note that
  if the url has no scheme delimiter it will also return true; we want
  this behaviour for canonicalize_url/1 to work as expected with urls
  like "some_blog.blog.com"